### PR TITLE
fix(model): Fix wrong mutability assumption in `IpmProvider` implementation

### DIFF
--- a/src/main/java/de/rub/nds/anvilcore/model/IpmProvider.java
+++ b/src/main/java/de/rub/nds/anvilcore/model/IpmProvider.java
@@ -43,8 +43,9 @@ public class IpmProvider {
     }
 
     private static List<ParameterIdentifier> getParameterIdentifiersForScope(DerivationScope derivationScope) {
+        final List<ParameterIdentifier> parameterIdentifiers = new ArrayList<>();
         // Get base parameters of model
-        List<ParameterIdentifier> parameterIdentifiers = AnvilFactoryRegistry.get().getParameterIdentifierProvider().getModelParameterIdentifiers(derivationScope);
+        parameterIdentifiers.addAll(AnvilFactoryRegistry.get().getParameterIdentifierProvider().getModelParameterIdentifiers(derivationScope));
         // Add explicit extensions
         parameterIdentifiers.addAll(derivationScope.getIpmExtensions());
         // Remove explicit limitations


### PR DESCRIPTION
Before, the `getParameterIdentifiersForScope(DerivationScope)` method of `IpmProvider` relied on the assumption that lists returned by `ParameterIdentifierProvider.getModelParameterIdentifiers(DerivationScope)` are always mutable. However, this is not part of the interface. It's perfectly valid to return a simple, immutable list, which lead to the following crash:

    java.lang.UnsupportedOperationException
            at java.base/java.util.ImmutableCollections.uoe(ImmutableCollections.java:72)
            at java.base/java.util.ImmutableCollections$AbstractImmutableCollection.addAll(ImmutableCollections.java:77)
            at de.rub.nds.anvilcore.model.IpmProvider.getParameterIdentifiersForScope(IpmProvider.java:49)
            at de.rub.nds.anvilcore.model.IpmProvider.mustUseSimpleModel(IpmProvider.java:29)
            at de.rub.nds.anvilcore.junit.TestChooserExtension.supportsTestTemplate(TestChooserExtension.java:29)
            at org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor.lambda$validateProviders$3(TestTemplateTestDescriptor.java:118)
            at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:176)
            at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
            at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
            at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
            at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
            at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
            at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:312)
            at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
            at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
            at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
            at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
            at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
            at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
            at org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor.validateProviders(TestTemplateTestDescriptor.java:119)
            at org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor.execute(TestTemplateTestDescriptor.java:98)
            at org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor.execute(TestTemplateTestDescriptor.java:42)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
            at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
            at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
            at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
            at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
            at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
            at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
            at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
            at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
            at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
            at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
            at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
            at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
            at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
            at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
            at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
            at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
            at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
            at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
            at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
            at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
            at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
            at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
            at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
            at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
            at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
            at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)

Even worse, an implementation of `ParameterIdentifierProvider` that uses a *static* mutable list would even lead to silent manipulation and potentially wrong results.

This change fixes the issue by always constructing a new list.