### PR TITLE
refactor(model): Fix usage of raw `DerivationParameter` type

### DIFF
--- a/src/main/java/de/rub/nds/anvilcore/junit/simpletest/SimpleTestExtension.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/simpletest/SimpleTestExtension.java
@@ -3,6 +3,7 @@ package de.rub.nds.anvilcore.junit.simpletest;
 import de.rub.nds.anvilcore.annotation.TestChooser;
 import de.rub.nds.anvilcore.model.DerivationScope;
 import de.rub.nds.anvilcore.model.IpmProvider;
+import de.rub.nds.anvilcore.model.config.AnvilConfig;
 import de.rub.nds.anvilcore.model.parameter.DerivationParameter;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
@@ -33,7 +34,7 @@ public class SimpleTestExtension implements TestTemplateInvocationContextProvide
     @Override
     public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext extensionContext) {
         DerivationScope derivationScope = new DerivationScope(extensionContext);
-        List<DerivationParameter> dynamicParameterValues = (List<DerivationParameter>) IpmProvider.getSimpleModelVariations(derivationScope);
+        List<DerivationParameter<AnvilConfig, Object>> dynamicParameterValues = IpmProvider.getSimpleModelVariations(derivationScope);
         SimpleTestManagerContainer managerContainer = SimpleTestManagerContainer.getInstance();
         if(dynamicParameterValues != null) {
             managerContainer.addManagerByExtensionContext(extensionContext, dynamicParameterValues.size());

--- a/src/main/java/de/rub/nds/anvilcore/model/IpmProvider.java
+++ b/src/main/java/de/rub/nds/anvilcore/model/IpmProvider.java
@@ -1,6 +1,7 @@
 package de.rub.nds.anvilcore.model;
 
 import de.rub.nds.anvilcore.context.AnvilFactoryRegistry;
+import de.rub.nds.anvilcore.model.config.AnvilConfig;
 import de.rub.nds.anvilcore.model.constraint.ConditionalConstraint;
 import de.rub.nds.anvilcore.model.parameter.DerivationParameter;
 import de.rub.nds.anvilcore.model.parameter.ParameterFactory;
@@ -31,12 +32,12 @@ public class IpmProvider {
         return builders.length == 1;
     }
 
-    public static List<DerivationParameter> getSimpleModelVariations(DerivationScope derivationScope) {
+    public static List<DerivationParameter<AnvilConfig, Object>> getSimpleModelVariations(DerivationScope derivationScope) {
         List<ParameterIdentifier> parameterIdentifiers = getParameterIdentifiersForScope(derivationScope);
         for (ParameterIdentifier parameterIdentifier : parameterIdentifiers) {
-            DerivationParameter<?,?> parameter = ParameterFactory.getInstanceFromIdentifier(parameterIdentifier);
+            DerivationParameter<AnvilConfig, Object> parameter = ParameterFactory.getInstanceFromIdentifier(parameterIdentifier);
             if (parameter.canBeModeled(derivationScope)) {
-                List<DerivationParameter> parameters = parameter.getConstrainedParameterValues(derivationScope);
+                List<DerivationParameter<AnvilConfig, Object>> parameters = parameter.getConstrainedParameterValues(derivationScope);
             }
         }
         return null;
@@ -56,7 +57,7 @@ public class IpmProvider {
     private static Parameter.Builder[] getParameterBuilders(List<ParameterIdentifier> parameterIdentifiers, DerivationScope derivationScope) {
         List<Parameter.Builder> parameterBuilders = new ArrayList<>();
         for (ParameterIdentifier parameterIdentifier : parameterIdentifiers) {
-            DerivationParameter<?,?> parameter = ParameterFactory.getInstanceFromIdentifier(parameterIdentifier);
+            DerivationParameter<AnvilConfig, Object> parameter = ParameterFactory.getInstanceFromIdentifier(parameterIdentifier);
             if (parameter.canBeModeled(derivationScope)) {
                 parameterBuilders.add(parameter.getParameterBuilder(derivationScope));
                 // TODO: How to model bitmask params from tls anvil?
@@ -68,7 +69,7 @@ public class IpmProvider {
     private static Constraint[] getConstraintsForScope(List<ParameterIdentifier> parameterIdentifiers, DerivationScope derivationScope) {
         List<Constraint> applicableConstraints = new ArrayList<>();
         for (ParameterIdentifier parameterIdentifier : parameterIdentifiers) {
-            DerivationParameter<?,?> parameter = ParameterFactory.getInstanceFromIdentifier(parameterIdentifier);
+            DerivationParameter<AnvilConfig, Object> parameter = ParameterFactory.getInstanceFromIdentifier(parameterIdentifier);
             //if (parameter.canBeModeled(derivationScope)) {
                 List<ConditionalConstraint> conditionalConstraints = parameter.getConditionalConstraints(derivationScope);
                 for (ConditionalConstraint conditionalConstraint : conditionalConstraints) {
@@ -81,11 +82,11 @@ public class IpmProvider {
         return applicableConstraints.toArray(new Constraint[]{});
     }
 
-    public static List<DerivationParameter> getStaticParameterValues(DerivationScope derivationScope) {
-        List<DerivationParameter> staticParameterValues = new ArrayList<>();
+    public static List<DerivationParameter<AnvilConfig, Object>> getStaticParameterValues(DerivationScope derivationScope) {
+        List<DerivationParameter<AnvilConfig, Object>> staticParameterValues = new ArrayList<>();
         List<ParameterIdentifier> parameterIdentifiers = getParameterIdentifiersForScope(derivationScope);
         for (ParameterIdentifier parameterIdentifier : parameterIdentifiers) {
-            List<DerivationParameter> parameterValues =
+            List<DerivationParameter<AnvilConfig, Object>> parameterValues =
                     ParameterFactory.getInstanceFromIdentifier(parameterIdentifier).getConstrainedParameterValues(derivationScope);
             if (parameterValues.size() == 1) {
                 staticParameterValues.add(parameterValues.get(0));

--- a/src/main/java/de/rub/nds/anvilcore/model/parameter/DerivationParameter.java
+++ b/src/main/java/de/rub/nds/anvilcore/model/parameter/DerivationParameter.java
@@ -56,9 +56,9 @@ public abstract class DerivationParameter<ConfigType extends AnvilConfig, ValueT
 
     public void postProcessConfig(ConfigType config, DerivationScope derivationScope) {};
 
-    public abstract List<DerivationParameter> getParameterValues(DerivationScope derivationScope);
+    public abstract List<DerivationParameter<ConfigType, ValueType>> getParameterValues(DerivationScope derivationScope);
 
-    public List<DerivationParameter> getConstrainedParameterValues(DerivationScope derivationScope) {
+    public List<DerivationParameter<ConfigType, ValueType>> getConstrainedParameterValues(DerivationScope derivationScope) {
         if (derivationScope.hasExplicitValues(parameterIdentifier)) {
             return getExplicitValues(derivationScope);
         } else {
@@ -82,7 +82,7 @@ public abstract class DerivationParameter<ConfigType extends AnvilConfig, ValueT
     }
 
     public Parameter.Builder getParameterBuilder(DerivationScope derivationScope) {
-        List<DerivationParameter> parameterValues = getConstrainedParameterValues(derivationScope);
+        List<DerivationParameter<ConfigType, ValueType>> parameterValues = getConstrainedParameterValues(derivationScope);
         return Parameter
                 .parameter(parameterIdentifier.toString())
                 .values(parameterValues.toArray());
@@ -98,12 +98,12 @@ public abstract class DerivationParameter<ConfigType extends AnvilConfig, ValueT
 
     protected abstract DerivationParameter<ConfigType, ValueType> generateValue(ValueType selectedValue);
 
-    private List<DerivationParameter> getExplicitValues(DerivationScope derivationScope) {
+    private List<DerivationParameter<ConfigType, ValueType>> getExplicitValues(DerivationScope derivationScope) {
         try {
             String methodName = derivationScope.getExplicitValues().get(parameterIdentifier);
             Method method = derivationScope.getExtensionContext().getRequiredTestClass().getMethod(methodName, DerivationScope.class);
             Constructor constructor = derivationScope.getExtensionContext().getRequiredTestClass().getConstructor();
-            return (List<DerivationParameter>) method.invoke(constructor.newInstance(), derivationScope);
+            return (List<DerivationParameter<ConfigType, ValueType>>) method.invoke(constructor.newInstance(), derivationScope);
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException e) {
             LOGGER.error("Was unable to fetch explicit values for type " + parameterIdentifier, e);
             return Collections.emptyList();


### PR DESCRIPTION
Before, it was impossible to use Anvil-Core without encountering warnings like this:

    [WARNING] /path/to/some/type.java:[LL,CC] found raw type: de.rub.nds.anvilcore.model.parameter.DerivationParameter
      missing type arguments for generic class de.rub.nds.anvilcore.model.parameter.DerivationParameter<ConfigType,ValueType>