### PR TITLE
CLI test output improvement

### DIFF
--- a/src/main/java/de/rub/nds/anvilcore/coffee4j/junit/TestInputIterator.java
+++ b/src/main/java/de/rub/nds/anvilcore/coffee4j/junit/TestInputIterator.java
@@ -21,12 +21,13 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
- * A special {@link Iterator} since streaming a java {@link Queue} directly does not allow concurrent modification
- * of said queue. In our case this means that one cannot add test inputs to the execution queue while executing
- * elements from the queue. Consequently, it is not possible to add fault characterization test inputs.
- * Therefore, this iterator decouples the actual queue from the stream by having and internal queue and only allowing
- * access through well defined public methods.
- * This iterator is NOT thread-safe and should not be used with parallel test execution in junit-jupiter!
+ * A special {@link Iterator} since streaming a java {@link Queue} directly does not allow
+ * concurrent modification of said queue. In our case this means that one cannot add test inputs to
+ * the execution queue while executing elements from the queue. Consequently, it is not possible to
+ * add fault characterization test inputs. Therefore, this iterator decouples the actual queue from
+ * the stream by having and internal queue and only allowing access through well defined public
+ * methods. This iterator is NOT thread-safe and should not be used with parallel test execution in
+ * junit-jupiter!
  */
 class TestInputIterator implements Iterator<Combination> {
 

--- a/src/main/java/de/rub/nds/anvilcore/coffee4j/junit/TestInputIterator.java
+++ b/src/main/java/de/rub/nds/anvilcore/coffee4j/junit/TestInputIterator.java
@@ -1,10 +1,16 @@
+/*
+ * Anvil Core - A combinatorial testing framework for cryptographic protocols based on coffee4j
+ *
+ * Copyright 2022-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
 package de.rub.nds.anvilcore.coffee4j.junit;
 
 import de.rub.nds.anvilcore.context.AnvilContext;
 import de.rub.nds.anvilcore.junit.Utils;
 import de.rwth.swc.coffee4j.model.Combination;
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Queue;
@@ -12,6 +18,7 @@ import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * A special {@link Iterator} since streaming a java {@link Queue} directly does not allow concurrent modification
@@ -22,10 +29,10 @@ import java.util.concurrent.TimeUnit;
  * This iterator is NOT thread-safe and should not be used with parallel test execution in junit-jupiter!
  */
 class TestInputIterator implements Iterator<Combination> {
-    
+
     private final BlockingDeque<Combination> testInputQueue = new LinkedBlockingDeque<>();
     private final ExtensionContext extensionContext;
-    
+
     synchronized void add(Combination testInput) {
         testInputQueue.add(testInput);
     }
@@ -33,11 +40,12 @@ class TestInputIterator implements Iterator<Combination> {
     public TestInputIterator(ExtensionContext context) {
         extensionContext = context;
     }
-    
+
     @Override
     public boolean hasNext() {
-        String uniqueId = Utils.getTemplateContainerExtensionContext(extensionContext).getUniqueId();
-        while (!AnvilContext.getInstance().testIsFinished(uniqueId)) {
+        String uniqueId =
+                Utils.getTemplateContainerExtensionContext(extensionContext).getUniqueId();
+        while (!AnvilContext.getInstance().testRunIsFinished(uniqueId)) {
             try {
                 Combination nextTestInput = testInputQueue.poll(3, TimeUnit.SECONDS);
                 if (nextTestInput != null) {
@@ -52,7 +60,7 @@ class TestInputIterator implements Iterator<Combination> {
 
         return false;
     }
-    
+
     @Override
     public Combination next() {
         final Combination nextTestInput = testInputQueue.poll();

--- a/src/main/java/de/rub/nds/anvilcore/context/AnvilContext.java
+++ b/src/main/java/de/rub/nds/anvilcore/context/AnvilContext.java
@@ -36,8 +36,8 @@ public class AnvilContext {
 
     private final ParameterIdentifierProvider parameterIdentifierProvider;
 
-    private long totalTests = 0;
-    private long testsDone = 0;
+    private long totalTestRuns = 0;
+    private long testRunsDone = 0;
     private long testCases = 0;
     private final Date creationTime = new Date();
     private Date testStartTime;
@@ -140,13 +140,13 @@ public class AnvilContext {
         return detailsFailedTestCases;
     }
 
-    public synchronized void testFinished(AnvilTestRun testRun) {
+    public synchronized void testRunFinished(AnvilTestRun testRun) {
         String testRunUniqueId = testRun.getUniqueId();
         addDetailsFailedTestCases(testRun);
         finishedTestRuns.put(testRunUniqueId, true);
         overallScoreContainer.merge(activeTestRuns.get(testRunUniqueId).getScoreContainer());
         AnvilTestRun finishedContainer = activeTestRuns.remove(testRunUniqueId);
-        testsDone++;
+        testRunsDone++;
         if (finishedContainer.getTestCases() != null) {
             testCases += finishedContainer.getTestCases().size();
         }
@@ -163,7 +163,7 @@ public class AnvilContext {
         LOGGER.info(
                 String.format(
                         "%d/%d Tests finished (in %02d:%02d). Method: %s",
-                        testsDone, totalTests, minutes, seconds, uniqueIdCompact));
+                        testRunsDone, totalTestRuns, minutes, seconds, uniqueIdCompact));
 
         if (listener != null) {
             listener.onTestRunFinished(finishedContainer);
@@ -174,7 +174,7 @@ public class AnvilContext {
         return finishedTestRuns;
     }
 
-    public synchronized boolean testIsFinished(String uniqueId) {
+    public synchronized boolean testRunIsFinished(String uniqueId) {
         return finishedTestRuns.containsKey(uniqueId);
     }
 
@@ -190,20 +190,20 @@ public class AnvilContext {
         this.testStartTime = testStartTime;
     }
 
-    public long getTotalTests() {
-        return totalTests;
+    public long getTotalTestRuns() {
+        return totalTestRuns;
     }
 
-    public void setTotalTests(long totalTests) {
-        this.totalTests = totalTests;
+    public void setTotalTestRuns(long totalTestRuns) {
+        this.totalTestRuns = totalTestRuns;
     }
 
     public long getTestCases() {
         return testCases;
     }
 
-    public long getTestsDone() {
-        return testsDone;
+    public long getTestRunsDone() {
+        return testRunsDone;
     }
 
     public ScoreContainer getOverallScoreContainer() {
@@ -214,7 +214,7 @@ public class AnvilContext {
         return resultsTestRuns;
     }
 
-    public synchronized void addTestResult(TestResult result, AnvilTestRun testRun) {
+    public synchronized void addTestRunResult(TestResult result, AnvilTestRun testRun) {
         getResultsTestRuns().computeIfAbsent(result, k -> new LinkedList<>());
         getResultsTestRuns().get(result).add(testRun.getUniqueId());
     }

--- a/src/main/java/de/rub/nds/anvilcore/context/AnvilContext.java
+++ b/src/main/java/de/rub/nds/anvilcore/context/AnvilContext.java
@@ -155,15 +155,15 @@ public class AnvilContext {
         long minutes = TimeUnit.MILLISECONDS.toMinutes(timediff);
         long remainingSecondsInMillis = timediff - TimeUnit.MINUTES.toMillis(minutes);
         long seconds = TimeUnit.MILLISECONDS.toSeconds(remainingSecondsInMillis);
-        String uniqueIdCompact =
-                testRunUniqueId.replaceAll(
-                        "\\[engine:junit-jupiter]/|\\(org\\.junit\\.jupiter\\.params\\.aggregator\\.ArgumentsAccessor, de\\.rub\\.nds\\.tlstest\\.framework\\.execution\\.WorkflowRunner\\)",
-                        "");
 
         LOGGER.info(
                 String.format(
                         "%d/%d Tests finished (in %02d:%02d). Method: %s",
-                        testRunsDone, totalTestRuns, minutes, seconds, uniqueIdCompact));
+                        testRunsDone,
+                        totalTestRuns,
+                        minutes,
+                        seconds,
+                        testRun.getTestMethodName()));
 
         if (listener != null) {
             listener.onTestRunFinished(finishedContainer);

--- a/src/main/java/de/rub/nds/anvilcore/execution/TestRunner.java
+++ b/src/main/java/de/rub/nds/anvilcore/execution/TestRunner.java
@@ -139,7 +139,7 @@ public class TestRunner {
                                     || (source != null
                                             && source.getClass().equals(MethodSource.class));
                         });
-        context.setTotalTests(testcases);
+        context.setTotalTestRuns(testcases);
 
         if (context.getListener() != null) {
             context.getListener().beforeStart(testplan, testcases);

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/AnvilTestWatcher.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/AnvilTestWatcher.java
@@ -393,7 +393,7 @@ public class AnvilTestWatcher implements TestWatcher, ExecutionReporter, TestExe
                 .forEach(
                         entry -> {
                             TestResult testRunResult = entry.getKey();
-                            List<String> testRunsUniqueIds = entry.getValue();
+                            Set<String> testRunsUniqueIds = entry.getValue();
                             logMessage.append(
                                     String.format(
                                             "\n\t%d test runs %s",
@@ -415,7 +415,7 @@ public class AnvilTestWatcher implements TestWatcher, ExecutionReporter, TestExe
      *     test run. Returns an empty string if the test run result is not failed.
      */
     private String buildTestCaseFailureDetailsSummary(
-            TestResult testRunResult, List<String> testRunsUniqueIds) {
+            TestResult testRunResult, Set<String> testRunsUniqueIds) {
         StringBuilder logMessage = new StringBuilder();
 
         if (testRunResult == TestResult.FULLY_FAILED

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/AnvilTestWatcher.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/AnvilTestWatcher.java
@@ -147,6 +147,7 @@ public class AnvilTestWatcher implements TestWatcher, ExecutionReporter, TestExe
                     || testCase.getTestResult() == TestResult.NOT_SPECIFIED) {
                 // default to failed for all AssertionErrors
                 testCase.setTestResult(TestResult.FULLY_FAILED);
+                testCase.setFailedReason(cause);
             }
             testRun.setFailedReason(retrieveThrowableReason(cause));
         }

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/AnvilTestWatcher.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/AnvilTestWatcher.java
@@ -393,9 +393,7 @@ public class AnvilTestWatcher implements TestWatcher, ExecutionReporter, TestExe
     public synchronized void logTestPlanExecutionSummary(AnvilContext context) {
         StringBuilder logMessage = new StringBuilder("\nTest plan execution summary:");
         context.getResultsTestRuns().entrySet().stream()
-                .sorted(
-                        Map.Entry.comparingByKey(
-                                Comparator.comparing(TestResult::getValue).reversed()))
+                .sorted(Map.Entry.comparingByKey(TestResult.getComparator().reversed()))
                 .forEach(
                         entry -> {
                             TestResult testRunResult = entry.getKey();

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/EndpointConditionExtension.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/EndpointConditionExtension.java
@@ -56,6 +56,6 @@ public class EndpointConditionExtension extends SingleCheckCondition {
             return ConditionEvaluationResult.enabled("TestEndpointMode matches");
         }
 
-        return ConditionEvaluationResult.disabled("TestEndpointMode doesn't match, skipping test.");
+        return ConditionEvaluationResult.disabled("TestEndpointMode doesn't match");
     }
 }

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/ValueConstraintsConditionExtension.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/ValueConstraintsConditionExtension.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class ValueConstraintsConditionExtension extends SingleCheckCondition {
 
+    public static final String DISABLED_REASON =
+            "Specific features required for the test have not been met by the SUT for derivation parameter ";
+
     @Override
     public ConditionEvaluationResult evaluateUncachedCondition(ExtensionContext extensionContext) {
         if (extensionContext.getTestMethod().isEmpty()) {
@@ -29,8 +32,7 @@ public class ValueConstraintsConditionExtension extends SingleCheckCondition {
                         valueConstraint.getAffectedParameter().getInstance();
                 if (derivationParameter.hasNoApplicableValues(derivationScope)) {
                     return ConditionEvaluationResult.disabled(
-                            "No values supported required for parameter "
-                                    + derivationParameter.getParameterIdentifier());
+                            DISABLED_REASON + derivationParameter.getParameterIdentifier());
                 }
             }
             for (ParameterIdentifier explicitParameterIdentifier :
@@ -38,8 +40,7 @@ public class ValueConstraintsConditionExtension extends SingleCheckCondition {
                 DerivationParameter derivationParameter = explicitParameterIdentifier.getInstance();
                 if (derivationParameter.hasNoApplicableValues(derivationScope)) {
                     return ConditionEvaluationResult.disabled(
-                            "No values supported required for parameter "
-                                    + explicitParameterIdentifier);
+                            DISABLED_REASON + explicitParameterIdentifier);
                 }
             }
             return ConditionEvaluationResult.enabled("");

--- a/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestCase.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestCase.java
@@ -115,6 +115,28 @@ public class AnvilTestCase {
         this.associatedContainer = associatedContainer;
     }
 
+    /**
+     * Generates a string containing the failure reason and additional result information of a
+     * failed test case. This string is used for logging purposes.
+     *
+     * @return The generated string
+     */
+    public String getTestCaseFailureDetails() {
+        StringBuilder logMessage = new StringBuilder();
+        logMessage.append(
+                String.format(
+                        "Failure reason: %s.",
+                        getFailedReason() != null ? getFailedReason().getMessage() : "undefined"));
+        if (getAdditionalResultInformation() != null) {
+            logMessage.append(
+                    String.format(
+                            "Additional result info: %s.",
+                            getAdditionalResultInformation().toString()));
+        }
+
+        return logMessage.toString();
+    }
+
     public void addAdditionalResultInfo(String info) {
         if (additionalResultInformation == null) {
             additionalResultInformation = new ArrayList<>();

--- a/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestCase.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestCase.java
@@ -147,7 +147,7 @@ public class AnvilTestCase {
      *
      * @return The generated string
      */
-    public String getTestCaseFailureDetails() {
+    public String getFailureDetails() {
         StringBuilder logMessage = new StringBuilder();
         logMessage.append(
                 String.format(

--- a/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestCase.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestCase.java
@@ -125,12 +125,12 @@ public class AnvilTestCase {
         StringBuilder logMessage = new StringBuilder();
         logMessage.append(
                 String.format(
-                        "Failure reason: %s.",
+                        "failure reason: %s.",
                         getFailedReason() != null ? getFailedReason().getMessage() : "undefined"));
         if (getAdditionalResultInformation() != null) {
             logMessage.append(
                     String.format(
-                            "Additional result info: %s.",
+                            " Additional result info: %s.",
                             getAdditionalResultInformation().toString()));
         }
 

--- a/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestCase.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestCase.java
@@ -67,7 +67,7 @@ public class AnvilTestCase {
         this.extensionContext = extensionContext;
         this.displayName = extensionContext.getDisplayName();
         this.associatedContainer = AnvilTestRun.forExtensionContext(extensionContext);
-        this.associatedContainer.add(this);
+        this.associatedContainer.addTestCase(this);
         this.testResult = TestResult.NOT_SPECIFIED;
     }
 

--- a/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestRun.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestRun.java
@@ -348,13 +348,19 @@ public class AnvilTestRun {
         AnvilContext.getInstance().testFinished(uniqueId);
 
         // log test run summary
-        if (result == TestResult.DISABLED) {
-            LOGGER.info(
-                    "{} is disabled because {}",
-                    getTestMethodName() != null ? getTestMethodName() : "undefined",
-                    disabledReason != null ? disabledReason : "undefined");
-        } else {
-            logTestRun();
+        switch (result) {
+            case STRICTLY_SUCCEEDED:
+            case CONCEPTUALLY_SUCCEEDED:
+                break; // skip live logging for any successful test
+            case DISABLED:
+                LOGGER.info(
+                        "{} is disabled because {}",
+                        getTestMethodName() != null ? getTestMethodName() : "undefined",
+                        disabledReason != null ? disabledReason : "undefined");
+                break;
+            default:
+                logTestRun();
+                break;
         }
     }
 

--- a/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestRun.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestRun.java
@@ -16,6 +16,7 @@ import de.rub.nds.anvilcore.annotation.NonCombinatorialAnvilTest;
 import de.rub.nds.anvilcore.context.AnvilContext;
 import de.rub.nds.anvilcore.junit.Utils;
 import de.rub.nds.anvilcore.model.ParameterCombination;
+import de.rub.nds.anvilcore.teststate.reporting.MetadataFetcher;
 import de.rub.nds.anvilcore.teststate.reporting.ScoreContainer;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -116,8 +117,176 @@ public class AnvilTestRun {
     }
 
     @JsonUnwrapped
-    private Map getMetadata() {
+    private Map<?, ?> getMetadata() {
         return AnvilContext.getInstance().getMetadataFetcher().getRawMetadata(testId);
+    }
+
+    private Map<TestResult, List<AnvilTestCase>> groupTestCasesByResult() {
+        Map<TestResult, List<AnvilTestCase>> testCasesByResult = new EnumMap<>(TestResult.class);
+        testCases.forEach(
+                testCase -> {
+                    TestResult testCaseResult = testCase.getTestResult();
+                    testCasesByResult
+                            .computeIfAbsent(testCaseResult, mapKey -> new ArrayList<>())
+                            .add(testCase);
+                });
+
+        return testCasesByResult;
+    }
+
+    private List<TestResult> getFailureTestResults() {
+        return Arrays.asList(TestResult.FULLY_FAILED, TestResult.PARTIALLY_FAILED);
+    }
+
+    private List<AnvilTestCase> filterTestCasesByResult(TestResult testResult) {
+        return testCases.stream()
+                .filter(testCase -> testCase.getTestResult() == testResult)
+                .collect(Collectors.toList());
+    }
+
+    private Map<String, Integer> filterUniqueFailedTestCases(TestResult testResult) {
+        if (!getFailureTestResults().contains(testResult)) {
+            String failureResults =
+                    getFailureTestResults().stream()
+                            .map(Enum::name)
+                            .collect(Collectors.joining(" or "));
+            throw new IllegalArgumentException("Test result must be either " + failureResults);
+        }
+
+        Map<String, Integer> failedTestCasesDetails = new HashMap<>();
+        List<AnvilTestCase> failedTestCases = filterTestCasesByResult(testResult);
+
+        // create a frequency map of failure details for all failed test cases
+        for (AnvilTestCase failedTestCase : failedTestCases) {
+            String failureDetail = getTestCaseFailureDetails(failedTestCase);
+            failedTestCasesDetails.merge(failureDetail, 1, Integer::sum);
+        }
+
+        return failedTestCasesDetails;
+    }
+
+    /**
+     * Generates a string containing the failure reason and additional result information of a
+     * failed test case.
+     *
+     * @param failedTestCase The failed test case
+     * @return The generated string
+     */
+    private String getTestCaseFailureDetails(AnvilTestCase failedTestCase) {
+        StringBuilder logMessage = new StringBuilder();
+        logMessage.append(
+                String.format(
+                        "Failure reason: %s.",
+                        failedTestCase.getFailedReason() != null
+                                ? failedTestCase.getFailedReason()
+                                : "undefined"));
+        if (failedTestCase.getAdditionalResultInformation() != null) {
+            logMessage.append(
+                    String.format(
+                            "Additional result info: %s.",
+                            failedTestCase.getAdditionalResultInformation()));
+        }
+
+        return logMessage.toString();
+    }
+
+    /**
+     * This method generates a summary of the failure details for a given test result.
+     *
+     * @param testResult The test result for which the failure details summary is to be generated.
+     * @param failedTestCaseDetails A map where the keys are the detail messages of the failed test
+     *     cases and the values are the counts of how many times each detail message appears.
+     * @return A string containing the failure details summary for the given test result.
+     */
+    private String buildTestCaseFailureDetailsSummary(
+            TestResult testResult, Map<String, Integer> failedTestCaseDetails) {
+        StringJoiner logMessage = new StringJoiner("\n");
+        int totalFailures =
+                failedTestCaseDetails.values().stream().mapToInt(Integer::intValue).sum();
+        failedTestCaseDetails.forEach(
+                (detailMessage, detailCount) ->
+                        logMessage.add(
+                                String.format(
+                                        "%d/%d test cases %s. %s",
+                                        detailCount,
+                                        totalFailures,
+                                        testResult.toString(),
+                                        detailMessage)));
+
+        return logMessage.toString();
+    }
+
+    private String buildTestRunResultsSummary() {
+        Map<TestResult, List<AnvilTestCase>> testCasesByResult = groupTestCasesByResult();
+        int testCasesSize = testCases.size();
+
+        StringJoiner logMessage = new StringJoiner("\n");
+        logMessage.add(
+                String.format(
+                        "\nTest cases of test run %s by result:",
+                        testId != null ? testId : "undefined"));
+        testCasesByResult.forEach(
+                (testResult, mappedTestCases) -> {
+                    logMessage.add(
+                            String.format(
+                                    "%d/%d test cases %s.",
+                                    mappedTestCases.size(), testCasesSize, testResult.toString()));
+                });
+
+        return logMessage.toString();
+    }
+
+    private String buildTestRunFailureDetailsSummary() {
+        Map<TestResult, List<AnvilTestCase>> testCasesByResult = groupTestCasesByResult();
+        StringBuilder logMessage = new StringBuilder();
+
+        // log details of failed test cases
+        List<TestResult> failureResults = getFailureTestResults();
+        if (testCasesByResult.keySet().stream().anyMatch(failureResults::contains)) {
+            logMessage.append("\nDetails of failed test cases:\n");
+            for (TestResult failureResult : failureResults) {
+                if (testCasesByResult.get(failureResult) != null) {
+                    logMessage.append(
+                            buildTestCaseFailureDetailsSummary(
+                                    failureResult, filterUniqueFailedTestCases(failureResult)));
+                }
+            }
+        }
+
+        return logMessage.toString();
+    }
+
+    private void logTestRun() {
+        MetadataFetcher metadataFetcher = AnvilContext.getInstance().getMetadataFetcher();
+        StringBuilder logMessage = new StringBuilder();
+
+        String methodName = getTestMethodName() != null ? getTestMethodName() : "undefined";
+        String testIdValue = testId != null ? testId : "undefined";
+        String rfcNumber =
+                metadataFetcher.getRfcNumber(testId) != null
+                        ? metadataFetcher.getRfcNumber(testId).toString()
+                        : "undefined";
+        String rfcSection =
+                metadataFetcher.getRfcSection(testId) != null
+                        ? metadataFetcher.getRfcSection(testId)
+                        : "undefined";
+        String description =
+                metadataFetcher.getDescription(testId) != null
+                        ? metadataFetcher.getDescription(testId)
+                        : "undefined";
+        int testCaseSize = testCases.size();
+
+        logMessage.append(
+                String.format(
+                        "Test Method: %s\n\tTest UID: %s\n\tRFC source: RFC %s, section %s\n\tRFC description: %s\n\tTest cases: %d",
+                        methodName, testIdValue, rfcNumber, rfcSection, description, testCaseSize));
+
+        if (!testCases.isEmpty()) {
+            logMessage.append(buildTestRunResultsSummary());
+            logMessage.append(buildTestRunFailureDetailsSummary());
+        }
+
+        LOGGER.info(logMessage.toString());
     }
 
     @Override
@@ -177,14 +346,20 @@ public class AnvilTestRun {
             // only determine result automatically if it has not been set before
             result = resolveFinalResult();
         }
-        if (result == TestResult.DISABLED && getDisabledReason() != null) {
-            LOGGER.info("{} is disable because {}", getTestMethodName(), getDisabledReason());
-        }
         scoreContainer.updateForResult(result);
         AnvilContext.getInstance()
                 .addTestResult(result, testClass.getName() + "." + testMethod.getName());
         AnvilContext.getInstance().getMapper().saveTestRunToPath(this);
         AnvilContext.getInstance().testFinished(uniqueId);
+
+        if (result == TestResult.DISABLED) {
+            LOGGER.info(
+                    "{} is disabled because {}",
+                    getTestMethodName() != null ? getTestMethodName() : "undefined",
+                    disabledReason != null ? disabledReason : "undefined");
+        } else {
+            logTestRun();
+        }
     }
 
     public TestResult resolveFinalResult() {

--- a/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestRun.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestRun.java
@@ -161,7 +161,7 @@ public class AnvilTestRun {
         failedTestCases.forEach(
                 failedTestCase ->
                         failedTestCasesDetails.merge(
-                                failedTestCase.getTestCaseFailureDetails(), 1, Integer::sum));
+                                failedTestCase.getFailureDetails(), 1, Integer::sum));
 
         return failedTestCasesDetails;
     }
@@ -345,7 +345,7 @@ public class AnvilTestRun {
         scoreContainer.updateForResult(result);
         AnvilContext.getInstance().addTestResult(result, this);
         AnvilContext.getInstance().getMapper().saveTestRunToPath(this);
-        AnvilContext.getInstance().testFinished(uniqueId);
+        AnvilContext.getInstance().testFinished(this);
 
         // log test run summary
         switch (result) {

--- a/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestRun.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestRun.java
@@ -262,7 +262,7 @@ public class AnvilTestRun {
             logMessage.append(buildTestRunFailureDetailsSummary());
         }
 
-        LOGGER.info(logMessage.toString());
+        LOGGER.warn(logMessage.toString());
     }
 
     @Override
@@ -354,7 +354,7 @@ public class AnvilTestRun {
                 break; // skip live logging for any successful test
             case DISABLED:
                 LOGGER.info(
-                        "{} is disabled because {}",
+                        "{} is disabled because: {}",
                         getTestMethodName() != null ? getTestMethodName() : "undefined",
                         disabledReason != null ? disabledReason : "undefined");
                 break;

--- a/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestRun.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/AnvilTestRun.java
@@ -343,9 +343,9 @@ public class AnvilTestRun {
             result = resolveFinalResult();
         }
         scoreContainer.updateForResult(result);
-        AnvilContext.getInstance().addTestResult(result, this);
+        AnvilContext.getInstance().addTestRunResult(result, this);
         AnvilContext.getInstance().getMapper().saveTestRunToPath(this);
-        AnvilContext.getInstance().testFinished(this);
+        AnvilContext.getInstance().testRunFinished(this);
 
         // log test run summary
         switch (result) {
@@ -466,9 +466,9 @@ public class AnvilTestRun {
         return scoreContainer;
     }
 
-    public void add(AnvilTestCase testState) {
-        testState.setAssociatedContainer(this);
-        this.testCases.add(testState);
+    public void addTestCase(AnvilTestCase testCase) {
+        testCase.setAssociatedContainer(this);
+        this.testCases.add(testCase);
     }
 
     public void setFailureInducingCombinations(

--- a/src/main/java/de/rub/nds/anvilcore/teststate/TestResult.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/TestResult.java
@@ -9,6 +9,7 @@
 package de.rub.nds.anvilcore.teststate;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 public enum TestResult {
@@ -26,6 +27,10 @@ public enum TestResult {
     TestResult(int value, int scorePercentage) {
         this.value = value;
         this.scorePercentage = scorePercentage;
+    }
+
+    public static Comparator<TestResult> getComparator() {
+        return Comparator.comparingInt(TestResult::getValue);
     }
 
     public int getValue() {

--- a/src/main/java/de/rub/nds/anvilcore/teststate/reporting/AnvilReport.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/reporting/AnvilReport.java
@@ -115,8 +115,8 @@ public class AnvilReport {
                         .collect(
                                 Collectors.groupingBy(
                                         String::toString, Collectors.summingInt(detail -> 1)));
-        this.totalTests = context.getTotalTests();
-        this.finishedTests = context.getTestsDone();
+        this.totalTests = context.getTotalTestRuns();
+        this.finishedTests = context.getTestRunsDone();
         this.testCaseCount = context.getTestCases();
         this.scoreContainer = context.getOverallScoreContainer();
         this.configString = context.getConfigString();

--- a/src/main/java/de/rub/nds/anvilcore/teststate/reporting/AnvilReport.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/reporting/AnvilReport.java
@@ -14,9 +14,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.rub.nds.anvilcore.constants.TestEndpointType;
 import de.rub.nds.anvilcore.context.AnvilContext;
+import de.rub.nds.anvilcore.teststate.AnvilTestCase;
 import de.rub.nds.anvilcore.teststate.TestResult;
 import java.util.Date;
 import java.util.LinkedList;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class AnvilReport {
     @JsonProperty("ElapsedTime")
@@ -49,6 +52,12 @@ public class AnvilReport {
     @JsonProperty("FullyFailedTests")
     private long testsFullyFailed;
 
+    @JsonProperty("DetailsFullyFailedTestCases")
+    private Map<String, Integer> detailsFullyFailedTestCases;
+
+    @JsonProperty("DetailsPartiallyFailedTestCases")
+    private Map<String, Integer> detailsPartiallyFailedTestCases;
+
     @JsonProperty("TestSuiteErrorTests")
     private long testsTestSuiteError;
 
@@ -76,27 +85,43 @@ public class AnvilReport {
         this.identifier = context.getConfig().getIdentifier();
         this.date = context.getCreationTime();
         this.testsDisabled =
-                context.getResultTestMap()
+                context.getResultsTestRuns()
                         .computeIfAbsent(TestResult.DISABLED, k -> new LinkedList<>())
                         .size();
         this.testsFullyFailed =
-                context.getResultTestMap()
+                context.getResultsTestRuns()
                         .computeIfAbsent(TestResult.FULLY_FAILED, k -> new LinkedList<>())
                         .size();
         this.testsStrictlySucceeded =
-                context.getResultTestMap()
+                context.getResultsTestRuns()
                         .computeIfAbsent(TestResult.STRICTLY_SUCCEEDED, k -> new LinkedList<>())
                         .size();
         this.testsPartiallyFailed =
-                context.getResultTestMap()
+                context.getResultsTestRuns()
                         .computeIfAbsent(TestResult.PARTIALLY_FAILED, k -> new LinkedList<>())
                         .size();
         this.testsConceptuallySucceeded =
-                context.getResultTestMap()
+                context.getResultsTestRuns()
                         .computeIfAbsent(TestResult.CONCEPTUALLY_SUCCEEDED, k -> new LinkedList<>())
                         .size();
+        this.detailsFullyFailedTestCases =
+                context
+                        .getResultsTestRuns()
+                        .computeIfAbsent(TestResult.FULLY_FAILED, k -> new LinkedList<>())
+                        .stream()
+                        .flatMap(testRun -> testRun.getTestCases().stream())
+                        .map(AnvilTestCase::getTestCaseFailureDetails)
+                        .collect(Collectors.toMap(String::toString, detail -> 1, Integer::sum));
+        this.detailsPartiallyFailedTestCases =
+                context
+                        .getResultsTestRuns()
+                        .computeIfAbsent(TestResult.PARTIALLY_FAILED, k -> new LinkedList<>())
+                        .stream()
+                        .flatMap(testRun -> testRun.getTestCases().stream())
+                        .map(AnvilTestCase::getTestCaseFailureDetails)
+                        .collect(Collectors.toMap(String::toString, detail -> 1, Integer::sum));
         this.testsTestSuiteError =
-                context.getResultTestMap()
+                context.getResultsTestRuns()
                         .computeIfAbsent(TestResult.TEST_SUITE_ERROR, k -> new LinkedList<>())
                         .size();
         this.totalTests = context.getTotalTests();

--- a/src/main/java/de/rub/nds/anvilcore/teststate/reporting/AnvilReport.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/reporting/AnvilReport.java
@@ -17,7 +17,6 @@ import de.rub.nds.anvilcore.context.AnvilContext;
 import de.rub.nds.anvilcore.teststate.TestResult;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/src/main/java/de/rub/nds/anvilcore/teststate/reporting/MetadataFetcher.java
+++ b/src/main/java/de/rub/nds/anvilcore/teststate/reporting/MetadataFetcher.java
@@ -33,6 +33,26 @@ public class MetadataFetcher {
         return (Map<String, Integer>) ((Map<?, ?>) this.metadataMap.get(id)).get("severityLevels");
     }
 
+    public String getDescription(String id) {
+        if (this.metadataMap.get(id) == null) return null;
+        return (String) ((Map<?, ?>) this.metadataMap.get(id)).get("description");
+    }
+
+    public Map<String, ?> getRfc(String id) {
+        if (this.metadataMap.get(id) == null) return null;
+        return (Map<String, ?>) ((Map<?, ?>) this.metadataMap.get(id)).get("rfc");
+    }
+
+    public Integer getRfcNumber(String id) {
+        if (this.getRfc(id) == null) return null;
+        return (Integer) getRfc(id).get("number");
+    }
+
+    public String getRfcSection(String id) {
+        if (this.getRfc(id) == null) return null;
+        return (String) getRfc(id).get("section");
+    }
+
     public Map<?, ?> getRawMetadata(String id) {
         return (Map<?, ?>) this.metadataMap.get(id);
     }


### PR DESCRIPTION
Improving the output by generating test run summaries [1] and a test plan execution summary [2].
Furthermore, this pull request adds failure details to Anvil report [3].


**[1] Test run summary example**

Test Method: de.rub.nds.tlstest.suite.tests.client.tls12.rfc8701.ServerInitiatedExtensionPoints.sendServerHelloGreaseExtension
	Test UID: 8701-KSVZP6dF7j
	RFC source: RFC 8701, section 3.1 Client Behavior
	RFC description: Clients MUST reject GREASE values when negotiated by the server. In particular, the client MUST fail the connection if a GREASE value appears in any of the following: [...] Any ServerHello extension
	Test cases: 37
Test cases of test run 8701-KSVZP6dF7j by result:
	37/37 test cases FULLY_FAILED.
Details of failed test cases:
	15/37 test cases FULLY_FAILED with failure reason: Expected a fatal alert but received DH_CLIENT_KEY_EXCHANGE,CHANGE_CIPHER_SPEC,FINISHED and socket is still open..
	6/37 test cases FULLY_FAILED with failure reason: Expected a fatal alert but received RSA_CLIENT_KEY_EXCHANGE,CHANGE_CIPHER_SPEC,FINISHED and socket is still open..
	16/37 test cases FULLY_FAILED with failure reason: Expected a fatal alert but received ECDH_CLIENT_KEY_EXCHANGE,CHANGE_CIPHER_SPEC,FINISHED and socket is still open..



**[2] Test plan execution summary example:**

Test plan execution summary:
	181 test runs STRICTLY_SUCCEEDED
	16 test runs FULLY_FAILED
		Details of failed test cases:
			101 failed with failure reason: undefined.
			62 failed with failure reason: Expected a fatal alert but received CHANGE_CIPHER_SPEC,CLIENT_HELLO and socket is still open..
			37 failed with failure reason: Expected a fatal alert but received FINISHED and socket is still open..
			37 failed with failure reason: Socket has not been closed.
			30 failed with failure reason: Expected a fatal alert but received CHANGE_CIPHER_SPEC,FINISHED and socket is still open..
			18 failed with failure reason: Expected a fatal alert but no messages have been received and socket is still open.
			16 failed with failure reason: Expected a fatal alert but received ECDH_CLIENT_KEY_EXCHANGE,CHANGE_CIPHER_SPEC,FINISHED and socket is still open..
			15 failed with failure reason: The workflow could not be executed as planned!.
			15 failed with failure reason: Expected a fatal alert but received DH_CLIENT_KEY_EXCHANGE,CHANGE_CIPHER_SPEC,FINISHED and socket is still open..
			13 failed with failure reason: Did not receive a KeyUpdate in response.
			6 failed with failure reason: Expected a fatal alert but received RSA_CLIENT_KEY_EXCHANGE,CHANGE_CIPHER_SPEC,FINISHED and socket is still open..
	235 test runs DISABLED


**[3] Anvil Report example (excerpt):**

"PartiallyFailedTests" : 0,
  "FullyFailedTests" : 16,
  "DetailsFullyFailedTestCases" : {
    "failure reason: Expected a fatal alert but received FINISHED and socket is still open.." : 37,
    "failure reason: The workflow could not be executed as planned!." : 15,
    "failure reason: Expected a fatal alert but received CHANGE_CIPHER_SPEC,FINISHED and socket is still open.." : 30,
    "failure reason: Did not receive a KeyUpdate in response." : 13,
    "failure reason: Expected a fatal alert but received DH_CLIENT_KEY_EXCHANGE,CHANGE_CIPHER_SPEC,FINISHED and socket is still open.." : 15,
    "failure reason: Socket has not been closed." : 37,
    "failure reason: Expected a fatal alert but received RSA_CLIENT_KEY_EXCHANGE,CHANGE_CIPHER_SPEC,FINISHED and socket is still open.." : 6,
    "failure reason: Expected a fatal alert but received ECDH_CLIENT_KEY_EXCHANGE,CHANGE_CIPHER_SPEC,FINISHED and socket is still open.." : 16,
    "failure reason: Expected a fatal alert but no messages have been received and socket is still open." : 18,
    "failure reason: undefined." : 101,
    "failure reason: Expected a fatal alert but received CHANGE_CIPHER_SPEC,CLIENT_HELLO and socket is still open.." : 62
  },
  "DetailsPartiallyFailedTestCases" : { },



