### PR TITLE
Cache Execution Conditions And DerivationScope

### DIFF
--- a/src/main/java/de/rub/nds/anvilcore/coffee4j/junit/TestCaseCreator.java
+++ b/src/main/java/de/rub/nds/anvilcore/coffee4j/junit/TestCaseCreator.java
@@ -28,7 +28,7 @@ public class TestCaseCreator implements BeforeTestExecutionCallback {
         AnvilTestCase testCase =
                 new AnvilTestCase(
                         ParameterCombination.fromCombination(
-                                testInput, new DerivationScope(extensionContext)),
+                                testInput, DerivationScope.fromExtensionContext(extensionContext)),
                         extensionContext);
         extensionContext
                 .getStore(ExtensionContext.Namespace.GLOBAL)

--- a/src/main/java/de/rub/nds/anvilcore/junit/AnvilTestBaseClass.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/AnvilTestBaseClass.java
@@ -43,7 +43,7 @@ public abstract class AnvilTestBaseClass {
     protected ParameterCombination resolveParameterCombination(
             ArgumentsAccessor argumentsAccessor) {
         return ParameterCombination.fromArgumentsAccessor(
-                argumentsAccessor, new DerivationScope(extensionContext));
+                argumentsAccessor, DerivationScope.fromExtensionContext(extensionContext));
     }
 
     protected ParameterCombination resolveParameterCombination(

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/EndpointConditionExtension.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/EndpointConditionExtension.java
@@ -14,14 +14,13 @@ import de.rub.nds.anvilcore.constants.TestEndpointType;
 import de.rub.nds.anvilcore.context.AnvilContext;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
-import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Evaluates the ClientTest, ServerTest, TestEndpoint annotations The test is disabled when a client
  * is tested but the test is written for servers.
  */
-public class EndpointConditionExtension implements ExecutionCondition {
+public class EndpointConditionExtension extends SingleCheckCondition {
 
     private TestEndpointType endpointOfMethod(ExtensionContext context) {
         Method testMethod = context.getRequiredTestMethod();
@@ -45,7 +44,7 @@ public class EndpointConditionExtension implements ExecutionCondition {
     }
 
     @Override
-    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+    public ConditionEvaluationResult evaluateUncachedCondition(ExtensionContext extensionContext) {
         if (!extensionContext.getTestMethod().isPresent()) {
             return ConditionEvaluationResult.enabled("Class annotations are not relevant.");
         }

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/MethodConditionExtension.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/MethodConditionExtension.java
@@ -16,14 +16,13 @@ import java.util.Arrays;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
-import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class MethodConditionExtension extends SingleCheckCondition implements ExecutionCondition {
+public class MethodConditionExtension extends SingleCheckCondition {
     private static final Logger LOGGER = LogManager.getLogger();
 
     @Override
-    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+    public ConditionEvaluationResult evaluateUncachedCondition(ExtensionContext extensionContext) {
         ConditionEvaluationResult evalResult = createInstance(extensionContext);
         if (evalResult == null) {
             Class<?> requiredTestClass = extensionContext.getRequiredTestClass();

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/MethodConditionExtension.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/MethodConditionExtension.java
@@ -23,49 +23,41 @@ public class MethodConditionExtension extends SingleCheckCondition {
 
     @Override
     public ConditionEvaluationResult evaluateUncachedCondition(ExtensionContext extensionContext) {
-        ConditionEvaluationResult evalResult = createInstance(extensionContext);
-        if (evalResult == null) {
-            Class<?> requiredTestClass = extensionContext.getRequiredTestClass();
-
-            if (extensionContext.getTestMethod().isEmpty()) {
-                evalResult = ConditionEvaluationResult.enabled("");
-            } else {
-                Method testMethod = extensionContext.getTestMethod().get();
-
-                Method classConditionMethod = null; // From test class annotation
-                Method methodConditionMethod = null; // From test method annotation
-                if (requiredTestClass.isAnnotationPresent(MethodCondition.class)) {
-                    MethodCondition methodConditionAnnotation =
-                            requiredTestClass.getAnnotation(MethodCondition.class);
-                    classConditionMethod =
-                            getMethodForAnnotation(methodConditionAnnotation, requiredTestClass);
-                }
-                if (testMethod.isAnnotationPresent(MethodCondition.class)) {
-                    MethodCondition methodConditionAnnotation =
-                            testMethod.getAnnotation(MethodCondition.class);
-                    methodConditionMethod =
-                            getMethodForAnnotation(methodConditionAnnotation, requiredTestClass);
-                }
-
-                if (methodConditionMethod == null && classConditionMethod == null) {
-                    evalResult = ConditionEvaluationResult.enabled("No MethodCondition found");
-                } else {
-
-                    if (methodConditionMethod != null) {
-                        evalResult = invokeMethod(methodConditionMethod, extensionContext);
-                    }
-
-                    if (classConditionMethod != null
-                            && (evalResult == null || !evalResult.isDisabled())) {
-                        evalResult = invokeMethod(classConditionMethod, extensionContext);
-                    }
-                }
-            }
-            cacheEvalResult(extensionContext, evalResult);
-            return evalResult;
-
+        Class<?> requiredTestClass = extensionContext.getRequiredTestClass();
+        if (extensionContext.getTestMethod().isEmpty()) {
+            return ConditionEvaluationResult.enabled("");
         } else {
-            return evalResult;
+            Method testMethod = extensionContext.getTestMethod().get();
+
+            Method classConditionMethod = null; // From test class annotation
+            Method methodConditionMethod = null; // From test method annotation
+            if (requiredTestClass.isAnnotationPresent(MethodCondition.class)) {
+                MethodCondition methodConditionAnnotation =
+                        requiredTestClass.getAnnotation(MethodCondition.class);
+                classConditionMethod =
+                        getMethodForAnnotation(methodConditionAnnotation, requiredTestClass);
+            }
+            if (testMethod.isAnnotationPresent(MethodCondition.class)) {
+                MethodCondition methodConditionAnnotation =
+                        testMethod.getAnnotation(MethodCondition.class);
+                methodConditionMethod =
+                        getMethodForAnnotation(methodConditionAnnotation, requiredTestClass);
+            }
+
+            if (methodConditionMethod == null && classConditionMethod == null) {
+                return ConditionEvaluationResult.enabled("No MethodCondition found");
+            } else {
+                ConditionEvaluationResult evalResult = null;
+                if (methodConditionMethod != null) {
+                    evalResult = invokeMethod(methodConditionMethod, extensionContext);
+                }
+
+                if (classConditionMethod != null
+                        && (evalResult == null || !evalResult.isDisabled())) {
+                    evalResult = invokeMethod(classConditionMethod, extensionContext);
+                }
+                return evalResult;
+            }
         }
     }
 

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/SingleCheckCondition.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/SingleCheckCondition.java
@@ -23,9 +23,6 @@ public abstract class SingleCheckCondition implements ExecutionCondition {
         if (evalResult == null) {
             evalResult = evaluateUncachedCondition(extensionContext);
             cacheEvalResult(extensionContext, evalResult);
-            System.out.println("Creating new instance");
-        } else {
-            System.out.println("Using cache");
         }
         return evalResult;
     }

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/SingleCheckCondition.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/SingleCheckCondition.java
@@ -30,7 +30,7 @@ public abstract class SingleCheckCondition implements ExecutionCondition {
     protected abstract ConditionEvaluationResult evaluateUncachedCondition(
             ExtensionContext extensionContext);
 
-    public ConditionEvaluationResult getPreviousEvaluationResult(
+    private ConditionEvaluationResult getPreviousEvaluationResult(
             ExtensionContext extensionContext) {
         ExtensionContext.Namespace namespace =
                 ExtensionContext.Namespace.create(
@@ -44,7 +44,7 @@ public abstract class SingleCheckCondition implements ExecutionCondition {
                 .get(this.getClass(), ConditionEvaluationResult.class);
     }
 
-    public void cacheEvalResult(
+    private void cacheEvalResult(
             ExtensionContext extensionContext, ConditionEvaluationResult evalResult) {
         if (extensionContext.getTestMethod().isPresent()) {
             // only cache for test methods as containers will only be checked once
@@ -54,14 +54,5 @@ public abstract class SingleCheckCondition implements ExecutionCondition {
                             extensionContext.getRequiredTestMethod());
             extensionContext.getStore(namespace).put(this.getClass(), evalResult);
         }
-    }
-
-    protected ConditionEvaluationResult createInstance(ExtensionContext extensionContext) {
-        ConditionEvaluationResult evalResult = null;
-        if (extensionContext.getTestMethod().isPresent()) {
-            // only check for methods as containers will always only be evaluated once
-
-        }
-        return evalResult;
     }
 }

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/SingleCheckCondition.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/SingleCheckCondition.java
@@ -1,0 +1,49 @@
+/*
+ * Anvil Core - A combinatorial testing framework for cryptographic protocols based on coffee4j
+ *
+ * Copyright 2022-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.anvilcore.junit.extension;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public abstract class SingleCheckCondition {
+    public ConditionEvaluationResult getPreviousEvaluationResult(
+            ExtensionContext extensionContext) {
+        ExtensionContext.Namespace namespace =
+                ExtensionContext.Namespace.create(
+                        extensionContext.getRequiredTestClass(),
+                        extensionContext.getRequiredTestMethod());
+        if (extensionContext.getStore(namespace).get(this.getClass()) == null) {
+            return null;
+        }
+        return extensionContext
+                .getStore(namespace)
+                .get(this.getClass(), ConditionEvaluationResult.class);
+    }
+
+    public void cacheEvalResult(
+            ExtensionContext extensionContext, ConditionEvaluationResult evalResult) {
+        if (extensionContext.getTestMethod().isPresent()) {
+            // only cache for test methods as containers will only be checked once
+            ExtensionContext.Namespace namespace =
+                    ExtensionContext.Namespace.create(
+                            extensionContext.getRequiredTestClass(),
+                            extensionContext.getRequiredTestMethod());
+            extensionContext.getStore(namespace).put(this.getClass(), evalResult);
+        }
+    }
+
+    protected ConditionEvaluationResult createInstance(ExtensionContext extensionContext) {
+        ConditionEvaluationResult evalResult = null;
+        if (extensionContext.getTestMethod().isPresent()) {
+            // only check for methods as containers will always only be evaluated once
+            evalResult = getPreviousEvaluationResult(extensionContext);
+        }
+        return evalResult;
+    }
+}

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/SingleCheckCondition.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/SingleCheckCondition.java
@@ -9,9 +9,30 @@
 package de.rub.nds.anvilcore.junit.extension;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public abstract class SingleCheckCondition {
+public abstract class SingleCheckCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        ConditionEvaluationResult evalResult = null;
+        if (extensionContext.getTestMethod().isPresent()) {
+            evalResult = getPreviousEvaluationResult(extensionContext);
+        }
+        if (evalResult == null) {
+            evalResult = evaluateUncachedCondition(extensionContext);
+            cacheEvalResult(extensionContext, evalResult);
+            System.out.println("Creating new instance");
+        } else {
+            System.out.println("Using cache");
+        }
+        return evalResult;
+    }
+
+    protected abstract ConditionEvaluationResult evaluateUncachedCondition(
+            ExtensionContext extensionContext);
+
     public ConditionEvaluationResult getPreviousEvaluationResult(
             ExtensionContext extensionContext) {
         ExtensionContext.Namespace namespace =
@@ -42,7 +63,7 @@ public abstract class SingleCheckCondition {
         ConditionEvaluationResult evalResult = null;
         if (extensionContext.getTestMethod().isPresent()) {
             // only check for methods as containers will always only be evaluated once
-            evalResult = getPreviousEvaluationResult(extensionContext);
+
         }
         return evalResult;
     }

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/ValueConstraintsConditionExtension.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/ValueConstraintsConditionExtension.java
@@ -19,44 +19,30 @@ public class ValueConstraintsConditionExtension extends SingleCheckCondition {
 
     @Override
     public ConditionEvaluationResult evaluateUncachedCondition(ExtensionContext extensionContext) {
-        ConditionEvaluationResult evalResult = createInstance(extensionContext);
-        if (evalResult == null) {
-            if (extensionContext.getTestMethod().isEmpty()) {
-                evalResult =
-                        ConditionEvaluationResult.enabled("Class annotations are not relevant");
-            } else {
-
-                DerivationScope derivationScope =
-                        DerivationScope.fromExtensionContext(extensionContext);
-                for (ValueConstraint valueConstraint : derivationScope.getValueConstraints()) {
-                    DerivationParameter derivationParameter =
-                            valueConstraint.getAffectedParameter().getInstance();
-                    if (derivationParameter.hasNoApplicableValues(derivationScope)) {
-                        evalResult =
-                                ConditionEvaluationResult.disabled(
-                                        "No values supported required for parameter "
-                                                + derivationParameter.getParameterIdentifier());
-                    }
-                }
-                for (ParameterIdentifier explicitParameterIdentifier :
-                        derivationScope.getExplicitValues().keySet()) {
-                    DerivationParameter derivationParameter =
-                            explicitParameterIdentifier.getInstance();
-                    if (derivationParameter.hasNoApplicableValues(derivationScope)) {
-                        evalResult =
-                                ConditionEvaluationResult.disabled(
-                                        "No values supported required for parameter "
-                                                + explicitParameterIdentifier);
-                    }
-                }
-            }
-            if (evalResult == null) {
-                evalResult = ConditionEvaluationResult.enabled("");
-            }
-            cacheEvalResult(extensionContext, evalResult);
-            return evalResult;
+        if (extensionContext.getTestMethod().isEmpty()) {
+            return ConditionEvaluationResult.enabled("Class annotations are not relevant");
         } else {
-            return evalResult;
+            DerivationScope derivationScope =
+                    DerivationScope.fromExtensionContext(extensionContext);
+            for (ValueConstraint valueConstraint : derivationScope.getValueConstraints()) {
+                DerivationParameter derivationParameter =
+                        valueConstraint.getAffectedParameter().getInstance();
+                if (derivationParameter.hasNoApplicableValues(derivationScope)) {
+                    return ConditionEvaluationResult.disabled(
+                            "No values supported required for parameter "
+                                    + derivationParameter.getParameterIdentifier());
+                }
+            }
+            for (ParameterIdentifier explicitParameterIdentifier :
+                    derivationScope.getExplicitValues().keySet()) {
+                DerivationParameter derivationParameter = explicitParameterIdentifier.getInstance();
+                if (derivationParameter.hasNoApplicableValues(derivationScope)) {
+                    return ConditionEvaluationResult.disabled(
+                            "No values supported required for parameter "
+                                    + explicitParameterIdentifier);
+                }
+            }
+            return ConditionEvaluationResult.enabled("");
         }
     }
 }

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/ValueConstraintsConditionExtension.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/ValueConstraintsConditionExtension.java
@@ -13,14 +13,12 @@ import de.rub.nds.anvilcore.model.constraint.ValueConstraint;
 import de.rub.nds.anvilcore.model.parameter.DerivationParameter;
 import de.rub.nds.anvilcore.model.parameter.ParameterIdentifier;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
-import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class ValueConstraintsConditionExtension extends SingleCheckCondition
-        implements ExecutionCondition {
+public class ValueConstraintsConditionExtension extends SingleCheckCondition {
 
     @Override
-    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+    public ConditionEvaluationResult evaluateUncachedCondition(ExtensionContext extensionContext) {
         ConditionEvaluationResult evalResult = createInstance(extensionContext);
         if (evalResult == null) {
             if (extensionContext.getTestMethod().isEmpty()) {

--- a/src/main/java/de/rub/nds/anvilcore/model/DerivationScope.java
+++ b/src/main/java/de/rub/nds/anvilcore/model/DerivationScope.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 public class DerivationScope {
+    private static final String EXTENSION_CONTEXT_STORE_KEY = "DerivationScope";
+
     private final String modelType;
     private final List<ParameterIdentifier> ipmLimitations;
     private final List<ParameterIdentifier> ipmExtensions;
@@ -33,7 +35,7 @@ public class DerivationScope {
     private final Set<ParameterIdentifier> manualConfigTypes;
     private final int testStrength;
 
-    public DerivationScope(ExtensionContext extensionContext) {
+    private DerivationScope(ExtensionContext extensionContext) {
         this.extensionContext = extensionContext;
         this.ipmLimitations = resolveIpmLimitations(extensionContext);
         this.ipmExtensions = resolveIpmExtensions(extensionContext);
@@ -43,6 +45,23 @@ public class DerivationScope {
         this.manualConfigTypes = resolveManualConfigTypes(extensionContext);
         this.testStrength = resolveTestStrength(extensionContext);
         this.modelType = resolveModelType(extensionContext);
+    }
+
+    public static DerivationScope fromExtensionContext(ExtensionContext extensionContext) {
+        ExtensionContext.Namespace namespace =
+                ExtensionContext.Namespace.create(
+                        extensionContext.getRequiredTestClass(),
+                        extensionContext.getRequiredTestMethod());
+        if (extensionContext.getStore(namespace) == null
+                || extensionContext.getStore(namespace).get(EXTENSION_CONTEXT_STORE_KEY) == null) {
+            DerivationScope newScope = new DerivationScope(extensionContext);
+            extensionContext.getStore(namespace).put(EXTENSION_CONTEXT_STORE_KEY, newScope);
+            return newScope;
+        } else {
+            return extensionContext
+                    .getStore(namespace)
+                    .get(EXTENSION_CONTEXT_STORE_KEY, DerivationScope.class);
+        }
     }
 
     // TODO Remove constructor, only for testing purposes

--- a/src/main/java/de/rub/nds/anvilcore/model/IpmProvider.java
+++ b/src/main/java/de/rub/nds/anvilcore/model/IpmProvider.java
@@ -38,7 +38,7 @@ public class IpmProvider implements ModelProvider, AnnotationConsumer<ModelFromS
 
     @Override
     public InputParameterModel provide(ExtensionContext extensionContext) {
-        DerivationScope derivationScope = new DerivationScope(extensionContext);
+        DerivationScope derivationScope = DerivationScope.fromExtensionContext(extensionContext);
         return generateIpm(derivationScope);
     }
 


### PR DESCRIPTION
Some of our execution conditions are a little more complex as the try to determine if required values are part of the IPM when applying all restrictions. By default, JUnit performs these checks for each test case, while the condition is either met or not met for the test method itself. This PR caches the result and also caches the DerivationScope so we do not instantiate multiple instances. A quick test based on 1000 iterations of the happyflow12 test using the old code and the new code with caching indicate a _slight_ performance improvement of around 100ms on average  on our VM. For me, this is mostly to have the code flow closer to expected behavior.