### PR TITLE
zip flag

### DIFF
--- a/src/main/java/de/rub/nds/anvilcore/context/AnvilTestConfig.java
+++ b/src/main/java/de/rub/nds/anvilcore/context/AnvilTestConfig.java
@@ -102,6 +102,9 @@ public class AnvilTestConfig {
             description = "Disables the packet capturing with tcpdump")
     private boolean disableTcpDump = false;
 
+    @Parameter(names = "-zip", description = "Pack the results folder into a zip archive.")
+    private boolean doZip = false;
+
     private TestEndpointType endpointMode;
     private String generalPcapFilter = "";
 
@@ -274,5 +277,13 @@ public class AnvilTestConfig {
 
     public void setGeneralPcapFilter(String generalPcapFilter) {
         this.generalPcapFilter = generalPcapFilter;
+    }
+
+    public boolean isDoZip() {
+        return doZip;
+    }
+
+    public void setDoZip(boolean doZip) {
+        this.doZip = doZip;
     }
 }

--- a/src/main/java/de/rub/nds/anvilcore/junit/extension/AnvilTestWatcher.java
+++ b/src/main/java/de/rub/nds/anvilcore/junit/extension/AnvilTestWatcher.java
@@ -16,6 +16,7 @@ import de.rub.nds.anvilcore.teststate.AnvilTestRun;
 import de.rub.nds.anvilcore.teststate.TestResult;
 import de.rub.nds.anvilcore.teststate.reporting.AnvilReport;
 import de.rub.nds.anvilcore.util.TestIdResolver;
+import de.rub.nds.anvilcore.util.ZipUtil;
 import de.rwth.swc.coffee4j.model.Combination;
 import de.rwth.swc.coffee4j.model.TestInputGroupContext;
 import de.rwth.swc.coffee4j.model.report.ExecutionReporter;
@@ -270,6 +271,10 @@ public class AnvilTestWatcher implements TestWatcher, ExecutionReporter, TestExe
         AnvilContext.getInstance().getMapper().saveReportToPath(anvilReport);
         if (AnvilContext.getInstance().getListener() != null) {
             AnvilContext.getInstance().getListener().onReportFinished(anvilReport);
+        }
+        if (AnvilContext.getInstance().getConfig().isDoZip()) {
+            ZipUtil.packFolderToZip(
+                    AnvilContext.getInstance().getConfig().getOutputFolder(), "report.zip");
         }
     }
 

--- a/src/main/java/de/rub/nds/anvilcore/util/ZipUtil.java
+++ b/src/main/java/de/rub/nds/anvilcore/util/ZipUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Anvil Core - A combinatorial testing framework for cryptographic protocols based on coffee4j
+ *
+ * Copyright 2022-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.anvilcore.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ZipUtil {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public static void packFolderToZip(String sourceDir, String zipFilename) {
+        try {
+            Path sourceDirPath = Paths.get(sourceDir);
+            Path zipFilePath = Files.createFile(sourceDirPath.resolve(zipFilename));
+            try (ZipOutputStream zs = new ZipOutputStream(Files.newOutputStream(zipFilePath));
+                    Stream<Path> paths = Files.walk(sourceDirPath)) {
+                paths.filter(path -> !Files.isDirectory(path))
+                        .filter(path -> !path.equals(zipFilePath))
+                        .forEach(
+                                path -> {
+                                    ZipEntry zipEntry =
+                                            new ZipEntry(sourceDirPath.relativize(path).toString());
+                                    try {
+                                        zs.putNextEntry(zipEntry);
+                                        Files.copy(path, zs);
+                                        zs.closeEntry();
+                                    } catch (IOException e) {
+                                        LOGGER.error("Error writing to zip file: ", e);
+                                    }
+                                });
+            }
+        } catch (IOException e) {
+            LOGGER.error("Error writing zip file: ", e);
+        }
+    }
+}


### PR DESCRIPTION
Adds a -zip flag, that automatically creates a zip archive of the results on top of the regular output, for easier uploading to Anvil Web