### PR TITLE
ci: Replace deprecated coverage plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 
     environment {
         JDK_TOOL_NAME = 'JDK 11'
-        MAVEN_TOOL_NAME = 'Maven 3.8.6'
+        MAVEN_TOOL_NAME = 'Maven 3.9.9'
     }
 
     options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,10 @@ pipeline {
                     junit testResults: '**/target/failsafe-reports/TEST-*.xml', allowEmptyResults: true
                 }
                 success {
-                    publishCoverage adapters: [jacoco(mergeToOneReport: true, path: '**/target/site/jacoco/jacoco.xml')]
+                    discoverReferenceBuild()
+                    recordCoverage(tools: [[ parser: 'JACOCO' ]],
+                            id: 'jacoco', name: 'JaCoCo Coverage',
+                            sourceCodeRetention: 'LAST_BUILD')
                 }
             }
         }


### PR DESCRIPTION
- Update Maven used by Jenkins to 3.9.9
- Replace deprecated publishCoverage plugin by recordCoverage