### PR TITLE
Pass context id to parameter provider

### DIFF
--- a/src/main/java/de/rub/nds/anvilcore/context/AnvilContext.java
+++ b/src/main/java/de/rub/nds/anvilcore/context/AnvilContext.java
@@ -30,7 +30,8 @@ public class AnvilContext {
     private final String configString;
     private final AnvilJsonMapper mapper;
     private static final MetadataFetcher metadataFetcher = new MetadataFetcher();
-    ;
+    private final String contextId;
+
     private AnvilListener listener;
 
     private final ParameterIdentifierProvider parameterIdentifierProvider;
@@ -71,11 +72,15 @@ public class AnvilContext {
     private boolean aborted = false;
 
     AnvilContext(
-            AnvilTestConfig config, String configString, ParameterIdentifierProvider provider) {
+            AnvilTestConfig config,
+            String configString,
+            ParameterIdentifierProvider provider,
+            String contextId) {
         this.parameterIdentifierProvider = provider;
         this.config = config;
         this.configString = configString;
         this.mapper = new AnvilJsonMapper(config);
+        this.contextId = contextId;
     }
 
     public void abortRemainingTests() {
@@ -223,5 +228,9 @@ public class AnvilContext {
 
     public String getConfigString() {
         return configString;
+    }
+
+    public String getContextId() {
+        return contextId;
     }
 }

--- a/src/main/java/de/rub/nds/anvilcore/context/AnvilContextRegistry.java
+++ b/src/main/java/de/rub/nds/anvilcore/context/AnvilContextRegistry.java
@@ -36,7 +36,7 @@ public class AnvilContextRegistry {
     public static String createContext(
             AnvilTestConfig config, String configString, ParameterIdentifierProvider provider) {
         String contextId = "anvil-context-" + ID_COUNTER.incrementAndGet();
-        AnvilContext context = new AnvilContext(config, configString, provider);
+        AnvilContext context = new AnvilContext(config, configString, provider, contextId);
         CONTEXTS.put(contextId, context);
         return contextId;
     }

--- a/src/main/java/de/rub/nds/anvilcore/model/ParameterIdentifierProvider.java
+++ b/src/main/java/de/rub/nds/anvilcore/model/ParameterIdentifierProvider.java
@@ -21,12 +21,14 @@ public abstract class ParameterIdentifierProvider {
     public static List<ParameterIdentifier> getAllParameterIdentifiers(AnvilContext context) {
         if (allParameterIdentifiers == null) {
             allParameterIdentifiers =
-                    context.getParameterIdentifierProvider().generateAllParameterIdentifiers();
+                    context.getParameterIdentifierProvider()
+                            .generateAllParameterIdentifiers(context.getContextId());
         }
         return allParameterIdentifiers;
     }
 
-    public abstract List<ParameterIdentifier> generateAllParameterIdentifiers();
+    public abstract List<ParameterIdentifier> generateAllParameterIdentifiers(
+            String anvilContextId);
 
     public List<ParameterIdentifier> getModelParameterIdentifiers(DerivationScope derivationScope) {
         String modelType = derivationScope.getModelType();


### PR DESCRIPTION
Required for extensions which define their paramter identifiers based on the specific SUT (and therefore based on the specific test/anvil context)