### PR TITLE
Return single AnvilContext reference if there is no ID in ExtensionContext

### DIFF
--- a/src/main/java/de/rub/nds/anvilcore/context/AnvilContextRegistry.java
+++ b/src/main/java/de/rub/nds/anvilcore/context/AnvilContextRegistry.java
@@ -23,7 +23,7 @@ public class AnvilContextRegistry {
     private static final AtomicLong ID_COUNTER = new AtomicLong(0);
     private static final ConcurrentHashMap<String, AnvilContext> CONTEXTS =
             new ConcurrentHashMap<>();
-    private static final String CONTEXT_ID_PARAMETER = "anvil.context.id";
+    public static final String CONTEXT_ID_PARAMETER = "anvil.context.id";
 
     /**
      * Creates a new AnvilContext instance with a unique ID.

--- a/src/main/java/de/rub/nds/anvilcore/context/AnvilContextRegistry.java
+++ b/src/main/java/de/rub/nds/anvilcore/context/AnvilContextRegistry.java
@@ -24,6 +24,7 @@ public class AnvilContextRegistry {
     private static final ConcurrentHashMap<String, AnvilContext> CONTEXTS =
             new ConcurrentHashMap<>();
     public static final String CONTEXT_ID_PARAMETER = "anvil.context.id";
+    public static final String CONTEXT_ID_PREFIX = "anvil-context-";
 
     /**
      * Creates a new AnvilContext instance with a unique ID.
@@ -35,7 +36,7 @@ public class AnvilContextRegistry {
      */
     public static String createContext(
             AnvilTestConfig config, String configString, ParameterIdentifierProvider provider) {
-        String contextId = "anvil-context-" + ID_COUNTER.incrementAndGet();
+        String contextId = CONTEXT_ID_PREFIX + ID_COUNTER.incrementAndGet();
         AnvilContext context = new AnvilContext(config, configString, provider, contextId);
         CONTEXTS.put(contextId, context);
         return contextId;
@@ -88,7 +89,7 @@ public class AnvilContextRegistry {
         String contextId =
                 testPlan.getConfigurationParameters().get(CONTEXT_ID_PARAMETER).orElse(null);
         if (contextId == null) {
-            return null;
+            return getSingleContextOrNull();
         }
         return getContext(contextId);
     }
@@ -104,7 +105,7 @@ public class AnvilContextRegistry {
     public static AnvilContext byExtensionContext(ExtensionContext extensionContext) {
         String contextId = getContextIdFromExtensionContext(extensionContext);
         if (contextId == null) {
-            return null;
+            return getSingleContextOrNull();
         }
         return getContext(contextId);
     }
@@ -123,6 +124,19 @@ public class AnvilContextRegistry {
                 return contextId;
             }
             current = current.getParent().orElse(null);
+        }
+        return null;
+    }
+
+    /**
+     * Fallback method to return the single AnvilContext instance if the map holds exactly one
+     * entry. Requied to run tests through the IDE as the reference property will not be set.
+     *
+     * @return The single AnvilContext registered or null
+     */
+    private static AnvilContext getSingleContextOrNull() {
+        if (CONTEXTS.size() == 1) {
+            return CONTEXTS.values().iterator().next();
         }
         return null;
     }

--- a/src/main/java/de/rub/nds/anvilcore/execution/TestRunner.java
+++ b/src/main/java/de/rub/nds/anvilcore/execution/TestRunner.java
@@ -41,7 +41,6 @@ import org.junit.platform.launcher.core.LauncherFactory;
  * as a callback before or after test execution.
  */
 public class TestRunner {
-    public static final String CONTEXT_ID_PROPERTY = "anvil.context.id";
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final AnvilTestConfig config;
@@ -104,7 +103,8 @@ public class TestRunner {
                         .configurationParameter(
                                 "junit.jupiter.execution.parallel.config.fixed.parallelism",
                                 String.valueOf(config.getParallelTests()))
-                        .configurationParameter(CONTEXT_ID_PROPERTY, contextId);
+                        .configurationParameter(
+                                AnvilContextRegistry.CONTEXT_ID_PARAMETER, contextId);
 
         if (!config.getTags().isEmpty()) {
             builder.filters(TagFilter.includeTags(config.getTags()));


### PR DESCRIPTION
This PR aims to fix an issue when running tests through the IDE. In this case, we will not be able to set the test context property that holds the reference to our AnvilContext instance. If we only hold one instance, we now return this value if no matching contextId is found.